### PR TITLE
Tiny update for proper Catalina citizens

### DIFF
--- a/macOS/Launcher/LauncherApplication/AppDelegate.swift
+++ b/macOS/Launcher/LauncherApplication/AppDelegate.swift
@@ -24,31 +24,31 @@ extension AppDelegate: NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         
-        let mainAppIdentifier = "com.tiborbodecs.MainApplication"
+	let mainAppIdentifier = "com.tiborbodecs.MainApplication"
         let runningApps = NSWorkspace.shared.runningApplications
         let isRunning = !runningApps.filter { $0.bundleIdentifier == mainAppIdentifier }.isEmpty
         
         if !isRunning {
-            DistributedNotificationCenter.default().addObserver(self,
-                                                                selector: #selector(self.terminate),
-                                                                name: .killLauncher,
-                                                                object: mainAppIdentifier)
+            DistributedNotificationCenter.default().addObserver(self, 
+								selector: #selector(self.terminate), 
+								name: .killLauncher, 
+								object: mainAppIdentifier)
             
-            let path = Bundle.main.bundlePath as NSString
-            var components = path.pathComponents
-            components.removeLast()
-            components.removeLast()
-            components.removeLast()
-            components.append("MacOS")
-            components.append("MainApplication") //main app name
-            
-            let newPath = NSString.path(withComponents: components)
-            
-            NSWorkspace.shared.launchApplication(newPath)
+            let url = URL(fileURLWithPath: Bundle.main.bundlePath).deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+            let path = url.appendingPathComponent("MacOS").appendingPathComponent("MainApplication").path
+
+            if #available(OSX 10.15, *) {
+                NSWorkspace.shared.openApplication(at: url, 
+						   configuration: NSWorkspace.OpenConfiguration(), 
+						   completionHandler: nil)
+            } else {
+                NSWorkspace.shared.launchApplication(path)
+            }
         }
         else {
             self.terminate()
         }
     }
+	
 }
 


### PR DESCRIPTION
Since macOS 10.15 (Catalina) NSWorkspace.launchApplication() has been deprecated. I have replaced it by the new .openApplication(at: configuration: completionHandler:), which takes an URL instead of a String path, and– IMPORTANTLY– needs the URL of an app bundle ("MainApplication.app") and not an executable (MainApplication/Contents/MacOS/MainApplication")!

As, on the other hand, .openApplication() and .OpenConfiguration were not available before Catalina, I added a version check!